### PR TITLE
chore(test-coverage): Bot V2 Handler

### DIFF
--- a/__fixtures__/v2/events/bot/delete.json
+++ b/__fixtures__/v2/events/bot/delete.json
@@ -1,0 +1,14 @@
+{
+  "RequestType": "Delete",
+  "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexBotCustomResourcesS-Vr8FgPMcTkXN",
+  "ResponseURL": "https://example.com/cfn",
+  "StackId": "arn:aws:cloudformation:us-east-1:123456789000:stack/LexV2StackJesse-v2BotStackJesseNestedStackv2BotStackNestedStackResource2D5A2D2E-1QC5AJK7CCZJZ/a5df3160-d8ff-11eb-bd56-1230d186eea1",
+  "RequestId": "e28a1bb8-f5ae-4fcd-b304-c71b0aa32c27",
+  "LogicalResourceId": "V2TestBotCDKCustomV2LexBot",
+  "PhysicalResourceId": "1234",
+  "ResourceType": "AWS::CloudFormation::CustomResource",
+  "ResourceProperties": {
+    "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexBotCustomResourcesS-Vr8FgPMcTkXN",
+    "props": "{\"botTags\":{\"Deployer\":\"test@example.com\"},\"dataPrivacy\":{\"childDirected\":false},\"idleSessionTTLInSeconds\":80,\"roleArn\":\"arn:aws:iam::123456789000:role/LexCustomResourcesStack-v2LexCustomLambdaRoleD6144-17UINKA2H29EB\",\"description\":\"TEST\",\"botName\":\"V2_Test_Bot_CDK\"}"
+  }
+}

--- a/__fixtures__/v2/events/bot/index.ts
+++ b/__fixtures__/v2/events/bot/index.ts
@@ -1,5 +1,12 @@
+// NOTE: delete is a keyword - we can't import as `delete`
 import create from './create.json';
+import deleteEvent from './delete.json';
+import unknown from './unknown.json';
+import update from './update.json';
 
 export default {
   create,
+  delete: deleteEvent,
+  unknown,
+  update
 };

--- a/__fixtures__/v2/events/bot/unknown.json
+++ b/__fixtures__/v2/events/bot/unknown.json
@@ -1,0 +1,14 @@
+{
+  "RequestType": "WAFFLE",
+  "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexBotCustomResourcesS-Vr8FgPMcTkXN",
+  "ResponseURL": "https://example.com/cfn",
+  "StackId": "arn:aws:cloudformation:us-east-1:123456789000:stack/LexV2StackJesse-v2BotStackJesseNestedStackv2BotStackNestedStackResource2D5A2D2E-1QC5AJK7CCZJZ/a5df3160-d8ff-11eb-bd56-1230d186eea1",
+  "RequestId": "e28a1bb8-f5ae-4fcd-b304-c71b0aa32c27",
+  "LogicalResourceId": "V2TestBotCDKCustomV2LexBot",
+  "PhysicalResourceId": "1234",
+  "ResourceType": "AWS::CloudFormation::CustomResource",
+  "ResourceProperties": {
+    "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexBotCustomResourcesS-Vr8FgPMcTkXN",
+    "props": "{\"botTags\":{\"Deployer\":\"test@example.com\"},\"dataPrivacy\":{\"childDirected\":false},\"idleSessionTTLInSeconds\":80,\"roleArn\":\"arn:aws:iam::123456789000:role/LexCustomResourcesStack-v2LexCustomLambdaRoleD6144-17UINKA2H29EB\",\"description\":\"TEST\",\"botName\":\"V2_Test_Bot_CDK\"}"
+  }
+}

--- a/__fixtures__/v2/events/bot/update.json
+++ b/__fixtures__/v2/events/bot/update.json
@@ -1,0 +1,18 @@
+{
+  "RequestType": "Update",
+  "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:CustomResourceStackTestZA-v2LexBotCustomResourcesS-lAXUQkcY7EVR",
+  "ResponseURL": "https://example.com/cfn",
+  "StackId": "arn:aws:cloudformation:us-east-1:123456789000:stack/LexV2StackZACHTEST-v2BotStackZACHTESTNestedStackv2BotStackZACHTESTNestedStackResource8-19OBX333L3QFG/7f6b71a0-d860-11eb-83b9-0e72790b6507",
+  "RequestId": "cd9c932d-65d6-4ed4-a56d-3347f8144e49",
+  "LogicalResourceId": "V2TestBot",
+  "PhysicalResourceId": "1234",
+  "ResourceType": "AWS::CloudFormation::CustomResource",
+  "ResourceProperties": {
+    "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:CustomResourceStackTestZA-v2LexBotCustomResourcesS-lAXUQkcY7EVR",
+    "props": "{\"botTags\":{\"Deployer\":\"test@example.com\"},\"dataPrivacy\":{\"childDirected\":false},\"idleSessionTTLInSeconds\":100,\"roleArn\":\"arn:aws:iam::123456789000:role/LexCustomResourcesStack-v2LexCustomLambdaRoleD6144-17UINKA2H29EB\",\"description\":\"V2_Test_Bot_CDK\",\"botName\":\"V2_Test_Bot\"}"
+  },
+  "OldResourceProperties": {
+    "ServiceToken": "arn:aws:lambda:us-east-1:157153201295:function:CustomResourceStackTestZA-v2LexBotCustomResourcesS-lAXUQkcY7EVR",
+    "props": "{\"botTags\":{\"Deployer\":\"test1@example.com\"},\"dataPrivacy\":{\"childDirected\":false},\"idleSessionTTLInSeconds\":80,\"roleArn\":\"arn:aws:iam::123456789000:role/LexCustomResourcesStack-v2LexCustomLambdaRoleD6144-17UINKA2H29EB\",\"description\":\"V2_Test_Bot_CDK\",\"botName\":\"V2_Test_Bot\"}"
+  }
+}

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,0 +1,11 @@
+import nock from 'nock';
+
+export default async () => {
+  // globally disable HTTP requests in the test suite
+  nock.disableNetConnect();
+
+  // setup some fake AWS credentials
+  process.env.AWS_ACCESS_KEY_ID = 'aws_access_key_id';
+  process.env.AWS_SECRET_ACCESS_KEY = 'aws_secret_access_key';
+  process.env.AWS_REGION = 'us-west-2';
+};

--- a/__tests__/v2/handlers/lex-bot/index.test.ts
+++ b/__tests__/v2/handlers/lex-bot/index.test.ts
@@ -64,8 +64,6 @@ describe('v2-lex-bot-handler', () => {
   });
 
   describe('with an unknown event type', () => {
-    let response: { PhysicalResourceId?: string };
-
     it('throws an error', async () => {
       expect.assertions(1);
       await expect(handler(fixtures.v2.events.bot.unknown, {})).rejects.toEqual(

--- a/__tests__/v2/handlers/lex-bot/index.test.ts
+++ b/__tests__/v2/handlers/lex-bot/index.test.ts
@@ -22,4 +22,63 @@ describe('v2-lex-bot-handler', () => {
       expect(response.PhysicalResourceId).toBe('123');
     });
   });
+
+  describe('with an update event', () => {
+    let scope: nock.Scope;
+    let response: { PhysicalResourceId?: string };
+
+    beforeAll(async () => {
+      scope = nock('https://models-v2-lex.us-east-1.amazonaws.com/')
+        .put('/bots/1234')
+        .reply(200, '{"botId":"1234"}');
+      response = await handler(fixtures.v2.events.bot.update, {});
+    });
+
+    it('updates a bot via the SDK', () => {
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('returns the PhysicalResourceId', () => {
+      expect(response.PhysicalResourceId).toBe('1234');
+    });
+  });
+
+  describe('with a delete event', () => {
+    let scope: nock.Scope;
+    let response: { PhysicalResourceId?: string };
+
+    beforeAll(async () => {
+      scope = nock('https://models-v2-lex.us-east-1.amazonaws.com/')
+        .delete('/bots/1234')
+        .reply(200, '{"botId":"1234"}');
+      response = await handler(fixtures.v2.events.bot.delete, {});
+    });
+
+    it('deletes a bot via the SDK', () => {
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('returns the PhysicalResourceId', () => {
+      expect(response.PhysicalResourceId).toBe('1234');
+    });
+  });
+
+  describe('with an unknown event type', () => {
+    let response: { PhysicalResourceId?: string };
+
+    it('throws an error', async () => {
+      expect.assertions(1);
+      await expect(handler(fixtures.v2.events.bot.unknown, {})).rejects.toEqual(
+        new Error('Event request type unknown!')
+      );
+    });
+  });
+
+  describe('with an internal error', () => {
+    it('throws an error', async () => {
+      expect.assertions(1);
+      // Error: TypeError: Cannot read property 'props' of undefined
+      await expect(handler({}, {})).rejects.toBeInstanceOf(TypeError);
+    });
+  });
 });

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,17 +1,15 @@
 import type { Config } from '@jest/types';
-import nock from 'nock';
-
-// globally disable HTTP requests in the test suite
-nock.disableNetConnect();
-
-// set up some fake AWS credentials
-process.env.AWS_ACCESS_KEY_ID = 'aws_access_key_id';
-process.env.AWS_SECRET_ACCESS_KEY = 'aws_secret_access_key';
-process.env.AWS_REGION = 'us-west-2';
 
 const config: Config.InitialOptions = {
+  collectCoverage: true,
+  errorOnDeprecated: true,
+  verbose: true,
+  globalSetup: '<rootDir>/__tests__/setup.ts',
   transform: { '^.+\\.(t|j)s$': 'ts-jest' },
   testRegex: '/__tests__/*',
+  testPathIgnorePatterns: [
+    '<rootDir>/__tests__/setup.ts'
+  ],
   moduleFileExtensions: [
     'ts',
     'js',

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint . --ext .ts",
-    "test": "jest --coverage",
+    "test": "jest",
     "test:debug": "node --inspect-brk node_modules/jest/bin/jest.js --runInBand",
     "prepare": "npm run build",
     "prepublishOnly": "npm test && npm run lint",

--- a/src/v2/handlers/lex-bot/index.js
+++ b/src/v2/handlers/lex-bot/index.js
@@ -9,23 +9,23 @@ const handler = async (event, context) => {
   try {
     console.log(event, context);
     let params = JSON.parse(event.ResourceProperties.props);
-    const client = new LexModelsV2Client({ region: process.env.REGION || "us-east-1" });
+    const client = new LexModelsV2Client({ region: process.env.REGION || 'us-east-1' });
 
-    if (event.RequestType === "Create") {
+    if (event.RequestType === 'Create') {
       const command = new CreateBotCommand(params);
       let createResponse = await client.send(command);
       console.log(createResponse);
       return {
         PhysicalResourceId: createResponse.botId
       };
-    } else if (event.RequestType === "Delete") {
+    } else if (event.RequestType === 'Delete') {
       const deleteCommand = new DeleteBotCommand({ botId: event.PhysicalResourceId });
       let deleteResponse = await client.send(deleteCommand);
       console.log(deleteResponse);
       return {
         PhysicalResourceId: deleteResponse.botId
       };
-    } else if (event.RequestType === "Update") {
+    } else if (event.RequestType === 'Update') {
       params.botId = event.PhysicalResourceId;
       const updateCommand = new UpdateBotCommand(params);
       let updateResponse = await client.send(updateCommand);
@@ -34,12 +34,11 @@ const handler = async (event, context) => {
         PhysicalResourceId: updateResponse.botId
       };
     } else {
-      console.error("Event request type unknown!");
-      throw new Error("Event request type unknown!");
+      throw new Error('Event request type unknown!');
     }
   } catch (err) {
     console.error(err);
-    throw new Error(err);
+    throw err;
   }
 };
 


### PR DESCRIPTION
* Use a globalSetup script to configure the test suite instead as
  that's a more common pattern.
* Add tests for the `update` and  `delete` actions as well as
  error cases.
* Fix an issue in our error handling where we would re-throw the
  error as a new Error instance (losing the original error type
  in the process).