### PR TITLE
chore(test-coverage): Slot Type Resources

### DIFF
--- a/__fixtures__/v2/events/bot/delete.json
+++ b/__fixtures__/v2/events/bot/delete.json
@@ -2,7 +2,7 @@
   "RequestType": "Delete",
   "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexBotCustomResourcesS-Vr8FgPMcTkXN",
   "ResponseURL": "https://example.com/cfn",
-  "StackId": "arn:aws:cloudformation:us-east-1:123456789000:stack/LexV2StackJesse-v2BotStackJesseNestedStackv2BotStackNestedStackResource2D5A2D2E-1QC5AJK7CCZJZ/a5df3160-d8ff-11eb-bd56-1230d186eea1",
+  "StackId": "arn:aws:cloudformation:us-east-1:123456789000:stack/LexV2Stack-v2BotStackNestedStackv2BotStackNestedStackResource2D5A2D2E-1QC5AJK7CCZJZ/a5df3160-d8ff-11eb-bd56-1230d186eea1",
   "RequestId": "e28a1bb8-f5ae-4fcd-b304-c71b0aa32c27",
   "LogicalResourceId": "MyBot",
   "PhysicalResourceId": "BOT_ID",

--- a/__fixtures__/v2/events/bot/unknown.json
+++ b/__fixtures__/v2/events/bot/unknown.json
@@ -2,7 +2,7 @@
   "RequestType": "WAFFLE",
   "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexBotCustomResourcesS-Vr8FgPMcTkXN",
   "ResponseURL": "https://example.com/cfn",
-  "StackId": "arn:aws:cloudformation:us-east-1:123456789000:stack/LexV2StackJesse-v2BotStackJesseNestedStackv2BotStackNestedStackResource2D5A2D2E-1QC5AJK7CCZJZ/a5df3160-d8ff-11eb-bd56-1230d186eea1",
+  "StackId": "arn:aws:cloudformation:us-east-1:123456789000:stack/LexV2Stack-v2BotStackNestedStackv2BotStackNestedStackResource2D5A2D2E-1QC5AJK7CCZJZ/a5df3160-d8ff-11eb-bd56-1230d186eea1",
   "RequestId": "e28a1bb8-f5ae-4fcd-b304-c71b0aa32c27",
   "LogicalResourceId": "MyBot",
   "PhysicalResourceId": "BOT_ID",

--- a/__fixtures__/v2/events/index.ts
+++ b/__fixtures__/v2/events/index.ts
@@ -1,9 +1,11 @@
 import bot from './bot';
 import intent from './intent';
 import slot from './slot';
+import slotType from './slot-type';
 
 export default {
   bot,
   intent,
-  slot
+  slot,
+  slotType,
 };

--- a/__fixtures__/v2/events/slot-type/create.json
+++ b/__fixtures__/v2/events/slot-type/create.json
@@ -1,0 +1,13 @@
+{
+  "RequestType": "Create",
+  "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexSlotTypeCustomResou-o1Nqxysydzuz",
+  "ResponseURL": "https://example.com/cfn",
+  "StackId": "arn:aws:cloudformation:us-east-1:123456789000:stack/LexV2Stack-v2BotStackNestedStackv2BotStackNestedStackResource5D6BADFA-E5IV8MFL0GRZ/a6c1ba90-d9ee-11eb-9cc1-0e258982388f",
+  "RequestId": "1250be60-ef87-4085-86cf-bd5fd3b1e91e",
+  "LogicalResourceId": "PetSlotType",
+  "ResourceType": "AWS::CloudFormation::CustomResource",
+  "ResourceProperties": {
+    "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexSlotTypeCustomResou-o1Nqxysydzuz",
+    "props": "{\"botId\":\"BOT_ID\",\"localeId\":\"en_US\",\"slotTypeName\":\"PetType\",\"valueSelectionSetting\":{\"resolutionStrategy\":\"TopResolution\"},\"slotTypeValues\":[{\"sampleValue\":{\"value\":\"dog\"},\"synonyms\":[{\"value\":\"canine\"}]},{\"sampleValue\":{\"value\":\"cat\"},\"synonyms\":[{\"value\":\"feline\"}]}],\"description\":\"Pet Types\"}"
+  }
+}

--- a/__fixtures__/v2/events/slot-type/delete.json
+++ b/__fixtures__/v2/events/slot-type/delete.json
@@ -1,0 +1,14 @@
+{
+  "RequestType": "Delete",
+  "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexSlotTypeCustomResou-o1Nqxysydzuz",
+  "ResponseURL": "https://example.com/cfn",
+  "StackId": "arn:aws:cloudformation:us-east-1:123456789000:stack/LexV2Stack-v2BotStackNestedStackv2BotStackNestedStackResource5D6BADFA-E5IV8MFL0GRZ/a6c1ba90-d9ee-11eb-9cc1-0e258982388f",
+  "RequestId": "b7e8c7d7-9b48-41ee-a0e2-3a0535775112",
+  "LogicalResourceId": "PetSlotType",
+  "PhysicalResourceId": "SLOT_TYPE_ID",
+  "ResourceType": "AWS::CloudFormation::CustomResource",
+  "ResourceProperties": {
+    "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexSlotTypeCustomResou-o1Nqxysydzuz",
+    "props": "{\"botId\":\"BOT_ID\",\"localeId\":\"en_US\",\"slotTypeName\":\"PetType\",\"valueSelectionSetting\":{\"resolutionStrategy\":\"TopResolution\"},\"slotTypeValues\":[{\"sampleValue\":{\"value\":\"dog\"},\"synonyms\":[{\"value\":\"canine\"}]},{\"sampleValue\":{\"value\":\"cat\"},\"synonyms\":[{\"value\":\"feline\"}]}],\"description\":\"Pet Types\"}"
+  }
+}

--- a/__fixtures__/v2/events/slot-type/index.ts
+++ b/__fixtures__/v2/events/slot-type/index.ts
@@ -1,0 +1,11 @@
+import create from './create.json';
+import deleteEvent from './delete.json';
+import unknown from './unknown.json';
+import update from './update.json';
+
+export default {
+  create,
+  delete: deleteEvent,
+  unknown,
+  update,
+}

--- a/__fixtures__/v2/events/slot-type/unknown.json
+++ b/__fixtures__/v2/events/slot-type/unknown.json
@@ -1,0 +1,13 @@
+{
+  "RequestType": "WAFFLE",
+  "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexSlotTypeCustomResou-o1Nqxysydzuz",
+  "ResponseURL": "https://example.com/cfn",
+  "StackId": "arn:aws:cloudformation:us-east-1:123456789000:stack/LexV2Stack-v2BotStackNestedStackv2BotStackNestedStackResource5D6BADFA-E5IV8MFL0GRZ/a6c1ba90-d9ee-11eb-9cc1-0e258982388f",
+  "RequestId": "1250be60-ef87-4085-86cf-bd5fd3b1e91e",
+  "LogicalResourceId": "PetSlotType",
+  "ResourceType": "AWS::CloudFormation::CustomResource",
+  "ResourceProperties": {
+    "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexSlotTypeCustomResou-o1Nqxysydzuz",
+    "props": "{\"botId\":\"BOT_ID\",\"localeId\":\"en_US\",\"slotTypeName\":\"PetType\",\"valueSelectionSetting\":{\"resolutionStrategy\":\"TopResolution\"},\"slotTypeValues\":[{\"sampleValue\":{\"value\":\"dog\"},\"synonyms\":[{\"value\":\"canine\"}]},{\"sampleValue\":{\"value\":\"cat\"},\"synonyms\":[{\"value\":\"feline\"}]}],\"description\":\"Pet Types\"}"
+  }
+}

--- a/__fixtures__/v2/events/slot-type/update.json
+++ b/__fixtures__/v2/events/slot-type/update.json
@@ -1,0 +1,18 @@
+{
+  "RequestType": "Update",
+  "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexSlotTypeCustomResou-o1Nqxysydzuz",
+  "ResponseURL": "https://example.com/cfn",
+  "StackId": "arn:aws:cloudformation:us-east-1:123456789000:stack/LexV2Stack-v2BotStackNestedStackv2BotStackNestedStackResource5D6BADFA-E5IV8MFL0GRZ/a6c1ba90-d9ee-11eb-9cc1-0e258982388f",
+  "RequestId": "1250be60-ef87-4085-86cf-bd5fd3b1e91e",
+  "LogicalResourceId": "PetSlotType",
+  "PhysicalResourceId": "SLOT_TYPE_ID",
+  "ResourceType": "AWS::CloudFormation::CustomResource",
+  "ResourceProperties": {
+    "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexSlotTypeCustomResou-o1Nqxysydzuz",
+    "props": "{\"botId\":\"BOT_ID\",\"localeId\":\"en_US\",\"slotTypeName\":\"PetType\",\"valueSelectionSetting\":{\"resolutionStrategy\":\"TopResolution\"},\"slotTypeValues\":[{\"sampleValue\":{\"value\":\"dog\"},\"synonyms\":[{\"value\":\"canine\"}]},{\"sampleValue\":{\"value\":\"cat\"},\"synonyms\":[{\"value\":\"feline\"}]}],\"description\":\"Types of Pets\"}"
+  },
+  "OldResourceProperties": {
+    "ServiceToken": "arn:aws:lambda:us-east-1:123456789000:function:LexCustomResourcesStack-v-v2LexSlotTypeCustomResou-o1Nqxysydzuz",
+    "props": "{\"botId\":\"BOT_ID\",\"localeId\":\"en_US\",\"slotTypeName\":\"PetType\",\"valueSelectionSetting\":{\"resolutionStrategy\":\"TopResolution\"},\"slotTypeValues\":[{\"sampleValue\":{\"value\":\"dog\"},\"synonyms\":[{\"value\":\"canine\"}]},{\"sampleValue\":{\"value\":\"cat\"},\"synonyms\":[{\"value\":\"feline\"}]}],\"description\":\"Pet Types\"}"
+  }
+}

--- a/__tests__/v2/handlers/lex-slot-type/index.test.ts
+++ b/__tests__/v2/handlers/lex-slot-type/index.test.ts
@@ -54,7 +54,7 @@ describe('v2-lex-slot-type-handler', () => {
       response = await handler(fixtures.v2.events.slotType.delete, {});
     });
 
-    it('updates a slot type via the SDK', () => {
+    it('deletes a slot type via the SDK', () => {
       expect(scope.isDone()).toBe(true);
     });
 

--- a/__tests__/v2/handlers/lex-slot-type/index.test.ts
+++ b/__tests__/v2/handlers/lex-slot-type/index.test.ts
@@ -1,0 +1,74 @@
+import nock from 'nock';
+import { handler } from '../../../../src/v2/handlers/lex-slot-type/index.js';
+import fixtures from '../../../../__fixtures__';
+
+describe('v2-lex-slot-type-handler', () => {
+  describe('with a create event', () => {
+    let response: { PhysicalResourceId?: string };
+    let scope: nock.Scope;
+
+    beforeAll(async () => {
+      scope = nock('https://models-v2-lex.us-east-1.amazonaws.com/')
+        .put('/bots/BOT_ID/botversions/DRAFT/botlocales/en_US/slottypes')
+        .reply(200, '{"slotTypeId":"SLOT_TYPE_ID"}');
+      response = await handler(fixtures.v2.events.slotType.create, {});
+    });
+
+    it('creates a slot type via the SDK', () => {
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('returns the PhysicalResourceId', () => {
+      expect(response.PhysicalResourceId).toBe('SLOT_TYPE_ID');
+    });
+  });
+
+  describe('with an update event', () => {
+    let response: { PhysicalResourceId?: string };
+    let scope: nock.Scope;
+
+    beforeAll(async () => {
+      scope = nock('https://models-v2-lex.us-east-1.amazonaws.com/')
+        .put('/bots/BOT_ID/botversions/DRAFT/botlocales/en_US/slottypes/SLOT_TYPE_ID')
+        .reply(202, '{"slotTypeId":"SLOT_TYPE_ID"}');
+      response = await handler(fixtures.v2.events.slotType.update, {});
+    });
+
+    it('updates a slot type via the SDK', () => {
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('returns the PhysicalResourceId', () => {
+      expect(response.PhysicalResourceId).toBe('SLOT_TYPE_ID');
+    });
+  });
+
+  describe('with a delete event', () => {
+    let response: { PhysicalResourceId?: string };
+    let scope: nock.Scope;
+
+    beforeAll(async () => {
+      scope = nock('https://models-v2-lex.us-east-1.amazonaws.com/')
+        .delete('/bots/BOT_ID/botversions/DRAFT/botlocales/en_US/slottypes/SLOT_TYPE_ID')
+        .reply(204, '');
+      response = await handler(fixtures.v2.events.slotType.delete, {});
+    });
+
+    it('updates a slot type via the SDK', () => {
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('returns the PhysicalResourceId', () => {
+      expect(response.PhysicalResourceId).toBe('SLOT_TYPE_ID');
+    });
+  });
+
+  describe('with an unknown event type', () => {
+    it('throws an error', async () => {
+      expect.assertions(1);
+      await expect(handler(fixtures.v2.events.slotType.unknown, {})).rejects.toEqual(
+        new Error('WAFFLE is not supported!')
+      );
+    });
+  });
+});

--- a/src/v2/handlers/lex-bot/package.json
+++ b/src/v2/handlers/lex-bot/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "v2-lex-bot-handler",
-    "version": "0.1.0",
-    "private": true,
-    "type": "module",
-    "dependencies": {
-        "@aws-sdk/client-lex-models-v2": "^3.17.0"
-    }
+  "name": "v2-lex-bot-handler",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@aws-sdk/client-lex-models-v2": "^3.17.0"
+  }
 }

--- a/src/v2/handlers/lex-slot-type/package.json
+++ b/src/v2/handlers/lex-slot-type/package.json
@@ -1,8 +1,9 @@
 {
-    "name": "v2-lex-slot-type-handler",
-    "version": "0.1.0",
-    "private": true,
-    "dependencies": {
-        "@aws-sdk/client-lex-models-v2": "^3.17.0"
-    }
+  "name": "v2-lex-slot-type-handler",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@aws-sdk/client-lex-models-v2": "^3.17.0"
+  }
 }

--- a/src/v2/handlers/lex-slot/package.json
+++ b/src/v2/handlers/lex-slot/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "v2-lex-slot-handler",
-    "version": "0.1.0",
-    "private": true,
-    "type": "module",
-    "dependencies": {
-        "@aws-sdk/client-lex-models-v2": "^3.17.0"
-    }
+  "name": "v2-lex-slot-handler",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@aws-sdk/client-lex-models-v2": "^3.17.0"
+  }
 }


### PR DESCRIPTION
* Add full test coverage for the Lex V2 Slot Type custom resource
  handler.
* Refactor the handler to include a lexical scope (curly braces)
  for switch statement cases so that we can declare the `response`
  constant for each case.
* Prefer the use of the spread (`...`) operator for building
  SDK requests so we don't need to mutate a shared object.